### PR TITLE
Update version number and link pointing to Release notes

### DIFF
--- a/src/templates/footer.html
+++ b/src/templates/footer.html
@@ -3,7 +3,7 @@
     <ul>
       <li>
         <div class="logo"></div>
-        <h5>Version: 20171212</h5>
+        <h5>Version:  <a href="https://clariah.github.io/mediasuite-info/#release-notes">2.0</a></h5>
       </li>
     </ul>
     <ul>


### PR DESCRIPTION
Small update in the footer to get the latest version (2.0) and a link pointing to the Release Notes in the Github Info pages. 