### PR TITLE
Update links pointing to github pages

### DIFF
--- a/src/resources/pagesContent/data-page.json
+++ b/src/resources/pagesContent/data-page.json
@@ -7,5 +7,5 @@
     }
   },
   "help_header":"Data info",
-  "documentation_question-mark_data_page":"<p>This is an information page. The \"Visit CKAN\" link will redirect you to an external service, which is the CLARIAH Media Suite's instance of CKAN, built using the CKAN registration software. For more information, you can read the (<a target=\"_blank\" href=\"https://clariah.github.io/mediasuite-info/#docs-data\">Media Suite Data Documentation</a>).</p>"
+  "documentation_question-mark_data_page":"<p>This is an information page. The \"Visit CKAN\" link will redirect you to an external service, which is the CLARIAH Media Suite's instance of CKAN, built using the CKAN registration software. For more information, you can read the (<a target=\"_blank\" href=\"https://clariah.github.io/mediasuite-info/pages/data.html\">Media Suite Data Documentation</a>).</p>"
 }

--- a/src/resources/pagesContent/home-page.json
+++ b/src/resources/pagesContent/home-page.json
@@ -21,11 +21,11 @@
     }
   },
   "home_workspace":{
-    "text":"Personal and collaborative workspace that stores user data such as bookmakrs, annotations, and search sessions. Use your (SURF) university account to login the Clariah Workspace and unlock the full potential of the Media Suite!",
+    "text":"Personal and collaborative workspace that stores user data such as bookmarks, annotations, and search sessions. Use your (SURF) university account to login the Clariah Workspace and unlock the full potential of the Media Suite!",
     "links": {
       "link_more_info":{
         "link_value":"More information",
-        "link_url":"https://clariah.github.io/mediasuite-info/#docs-workspace"
+        "link_url":"https://clariah.github.io/mediasuite-info/pages/workspace.html"
       },
       "link_login":{
         "link_value":"Login",

--- a/src/resources/pagesContent/tools-page.json
+++ b/src/resources/pagesContent/tools-page.json
@@ -5,7 +5,7 @@
     "text":"The Media Suite tools offer the core functionalities needed for performing scholarly research tasks with audio-visual media and contextual collections. Tools available in this version of the Media Suite enable metadata inspection, exploratory browsing, search, visualization, and analysis (annotation support).",
     "links": {
       "link_value":"View documentation",
-      "link_url":"https://clariah.github.io/mediasuite-info/#docs-tools"
+      "link_url":"https://clariah.github.io/mediasuite-info/pages/tools.html"
     }
   },
   "tools_collection-inspector":{
@@ -14,7 +14,7 @@
     "links": {
       "link_details":{
         "link_value":"Details",
-        "link_url":"https://clariah.github.io/mediasuite-info/#docs-tools-inspect-metadata"
+        "link_url":"https://clariah.github.io/mediasuite-info/pages/tools.html#docs-tools-inspect-metadata"
       },
       "link_open":{
         "link_value":"Open",
@@ -28,7 +28,7 @@
     "links": {
       "link_details":{
         "link_value":"Details",
-        "link_url":"https://clariah.github.io/mediasuite-info/#docs-tools-browse-explore"
+        "link_url":"https://clariah.github.io/mediasuite-info/pages/tools.html#docs-tools-browse-explore"
       },
       "link_open":{
         "link_value":"Open",
@@ -42,7 +42,7 @@
     "links": {
       "link_details":{
         "link_value":"Details",
-        "link_url":"https://clariah.github.io/mediasuite-info/#docs-tools-compare"
+        "link_url":"https://clariah.github.io/mediasuite-info/pages/tools.html#docs-tools-compare"
       },
       "link_open":{
         "link_value":"Open",
@@ -56,7 +56,7 @@
     "links": {
       "link_details":{
         "link_value":"Details",
-        "link_url":"https://clariah.github.io/mediasuite-info/#docs-tools-search"
+        "link_url":"https://clariah.github.io/mediasuite-info/pages/tools.html#docs-tools-search"
       },
       "link_open":{
         "link_value":"Open",
@@ -66,7 +66,7 @@
   },
   "tools_tool-development":{
     "header":"Tool development",
-    "text":"QUITAR ESTE BLOQUE",
+    "text":"REMOVE THIS BLOCK",
     "links": {
       "link_value":"More informations",
       "link_url":"https://clariah.github.io/mediasuite-info/"

--- a/src/resources/recipes/collection-inspector.json
+++ b/src/resources/recipes/collection-inspector.json
@@ -4,7 +4,7 @@
 	"type" : "collection-analysis",
 	"phase" : "collection-exploration",
 	"description" : "With this recipe it is possible to: 1) select collections, 2) inspect their metadata, 3) perform data analytics tasks on their metadata (e.g., detect incomplete data, observe value distributions along date fields), and 4) send them to the other browsing and search recipes.",
-	"recipeDescription" : "<p>This recipe is made to support “data critique”. With this recipe it is possible to:</p><br /> 1) Select collections <br />2) Inspect their metadata <br />3) Perform data analytics tasks on their metadata (e.g., detect incomplete data, observe value distributions along date fields) <br /> 4) Send them to the other browsing and search recipes</br></br><a target=\"_blank\" href=\"https://clariah.github.io/mediasuite-info/#docs-tools-inspect-metadata\">More info</a>",
+	"recipeDescription" : "<p>This recipe is made to support “data critique”. With this recipe it is possible to:</p><br /> 1) Select collections <br />2) Inspect their metadata <br />3) Perform data analytics tasks on their metadata (e.g., detect incomplete data, observe value distributions along date fields) <br /> 4) Send them to the other browsing and search recipes</br></br><a target=\"_blank\" href=\"https://clariah.github.io/mediasuite-info/pages/tools.html#docs-tools-inspect-metadata\">More info</a>",
 	"inRecipeList" : true,
 	"ingredients" : {
 		"collectionAnalyser" : {

--- a/src/resources/recipes/comparative-search.json
+++ b/src/resources/recipes/comparative-search.json
@@ -4,7 +4,7 @@
 	"type" : "comparative-search",
 	"phase" : "search",
 	"description" : "Supports comparative (re)search based on multiple queries on the same or different collections.",
-	"recipeDescription" : "<p>Supports comparative (re)search based on multiple queries on the same or different collections of choice. </p></br></br><a target=\"_blank\" href=\"https://clariah.github.io/mediasuite-info/#docs-tools-compare\">More info</a>",
+	"recipeDescription" : "<p>Supports comparative (re)search based on multiple queries on the same or different collections of choice. </p></br></br><a target=\"_blank\" href=\"https://clariah.github.io/mediasuite-info/pages/tools.html#docs-tools-compare\">More info</a>",
 	"inRecipeList" : true,
 	"useCustomTemplate" : false,
 	"ingredients" : {

--- a/src/resources/recipes/single-search.json
+++ b/src/resources/recipes/single-search.json
@@ -4,7 +4,7 @@
 	"type" : "single-search",
 	"phase" : "search",
 	"description" : "Dedicated recipe for searching/exploring through a single collection and all available annotation layers for that collection (e.g., automatically-generated, user-generated, archival generated).",
-	"recipeDescription" : "<p>Dedicated recipe for searching/exploring through a single collection of choice by using facets and other filters.</p> </br></br><a target=\"_blank\" href=\"https://clariah.github.io/mediasuite-info/#docs-tools-search\">More info</a>",
+	"recipeDescription" : "<p>Dedicated recipe for searching/exploring through a single collection of choice by using facets and other filters.</p> </br></br><a target=\"_blank\" href=\"https://clariah.github.io/mediasuite-info/pages/tools.html#docs-tools-search\">More info</a>",
 	"inRecipeList" : true,
 	"ingredients" : {
 		"collectionSelector" : true,

--- a/src/templates/footer.html
+++ b/src/templates/footer.html
@@ -3,7 +3,7 @@
     <ul>
       <li>
         <div class="logo"></div>
-        <h5>Version:  <a href="https://clariah.github.io/mediasuite-info/#release-notes-v2">2.0</a></h5>
+        <h5>Version:  <a href="https://clariah.github.io/mediasuite-info/pages/release-notes.html#release-notes-v2">2.0</a></h5>
       </li>
     </ul>
     <ul>


### PR DESCRIPTION
Update links pointing to github pages
NOTE: UPDATE ONLY WHEN GITHUB info site has been modified from single page to several pages based on section name. 