### PR TITLE
Integrate documentation pages in Media Suite

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ pyparsing==2.2.0
 requests==2.13.0
 six==1.10.0
 urllib3==1.20
+Markdown==2.6.11

--- a/src/components/security/AuthenticationHub.py
+++ b/src/components/security/AuthenticationHub.py
@@ -48,10 +48,14 @@ class AuthenticationHub(object):
 	def getUser(self, request):
 		if self.app.config['AUTHENTICATION_METHOD'] == 'OpenConext':
 			if len(session)>0 and 'samlUserdata' in session:
+				attributes = {}
+				if type(session['samlUserdata']) == dict:
+					attributes = session['samlUserdata']
+					attributes['allowPersonalCollections'] = True
 				return {
 					'id' : session['samlUserdata']['urn:mace:dir:attribute-def:uid'][0], #TODO is there a real ID?
 					'name' : session['samlUserdata']['urn:mace:dir:attribute-def:uid'][0],
-					'attributes' : session['samlUserdata']
+					'attributes' : attributes
 				}
 		elif self.isAuthenticated(request): #basic auth
 			return {

--- a/src/resources/pagesContent/about-page.json
+++ b/src/resources/pagesContent/about-page.json
@@ -9,7 +9,7 @@
     },
     "documentation":{
       "value":"Media Suite Documentation",
-      "url":"https://clariah.github.io/mediasuite-info/"
+      "url":"/documentation/"
     },
     "blog":{
       "value":"Visit our blog",

--- a/src/resources/pagesContent/data-page.json
+++ b/src/resources/pagesContent/data-page.json
@@ -7,5 +7,5 @@
     }
   },
   "help_header":"Data info",
-  "documentation_question-mark_data_page":"<p>This is an information page. The \"Visit CKAN\" link will redirect you to an external service, which is the CLARIAH Media Suite's instance of CKAN, built using the CKAN registration software. For more information, you can read the (<a target=\"_blank\" href=\"https://clariah.github.io/mediasuite-info/pages/data.html\">Media Suite Data Documentation</a>).</p>"
+  "documentation_question-mark_data_page":"<p>This is an information page. The \"Visit CKAN\" link will redirect you to an external service, which is the CLARIAH Media Suite's instance of CKAN, built using the CKAN registration software. For more information, you can read the (<a target=\"_blank\" href=\"/documentation/data\">Media Suite Data Documentation</a>).</p>"
 }

--- a/src/resources/pagesContent/tools-page.json
+++ b/src/resources/pagesContent/tools-page.json
@@ -64,6 +64,20 @@
       }
     }
   },
+  "tools_query-comparison":{
+    "header":"Compare",
+    "text":"This tool supports comparative analyses",
+    "links": {
+      "link_details":{
+        "link_value":"Details",
+        "link_url":"https://clariah.github.io/mediasuite-info/pages/tools.html#docs-tools-compare"
+      },
+      "link_open":{
+        "link_value":"Open",
+        "link_url":"/tool/query-comparison"
+      }
+    }
+  },
   "tools_tool-development":{
     "header":"Tool development",
     "text":"REMOVE THIS BLOCK",

--- a/src/resources/pagesContent/tools-page.json
+++ b/src/resources/pagesContent/tools-page.json
@@ -5,7 +5,7 @@
     "text":"The Media Suite tools offer the core functionalities needed for performing scholarly research tasks with audio-visual media and contextual collections. Tools available in this version of the Media Suite enable metadata inspection, exploratory browsing, search, visualization, and analysis (annotation support).",
     "links": {
       "link_value":"View documentation",
-      "link_url":"https://clariah.github.io/mediasuite-info/pages/tools.html"
+      "link_url":"/documentation/tools"
     }
   },
   "tools_collection-inspector":{
@@ -14,7 +14,7 @@
     "links": {
       "link_details":{
         "link_value":"Details",
-        "link_url":"https://clariah.github.io/mediasuite-info/pages/tools.html#docs-tools-inspect-metadata"
+        "link_url":"/documentation/tools/collection-inspector"
       },
       "link_open":{
         "link_value":"Open",
@@ -28,7 +28,7 @@
     "links": {
       "link_details":{
         "link_value":"Details",
-        "link_url":"https://clariah.github.io/mediasuite-info/pages/tools.html#docs-tools-browse-explore"
+        "link_url":"/documentation/tools/exploratory-search"
       },
       "link_open":{
         "link_value":"Open",
@@ -42,7 +42,7 @@
     "links": {
       "link_details":{
         "link_value":"Details",
-        "link_url":"https://clariah.github.io/mediasuite-info/pages/tools.html#docs-tools-compare"
+        "link_url":"/documentation/tools/query-comparison"
       },
       "link_open":{
         "link_value":"Open",
@@ -56,7 +56,7 @@
     "links": {
       "link_details":{
         "link_value":"Details",
-        "link_url":"https://clariah.github.io/mediasuite-info/pages/tools.html#docs-tools-search"
+        "link_url":"/documentation/tools/single-search"
       },
       "link_open":{
         "link_value":"Open",
@@ -70,7 +70,7 @@
     "links": {
       "link_details":{
         "link_value":"Details",
-        "link_url":"https://clariah.github.io/mediasuite-info/pages/tools.html#docs-tools-compare"
+        "link_url":"/documentation/tools/query-comparison"
       },
       "link_open":{
         "link_value":"Open",
@@ -83,7 +83,7 @@
     "text":"REMOVE THIS BLOCK",
     "links": {
       "link_value":"More informations",
-      "link_url":"https://clariah.github.io/mediasuite-info/"
+      "link_url":"/documentation/"
     }
   }
 }

--- a/src/resources/recipes/collection-inspector.json
+++ b/src/resources/recipes/collection-inspector.json
@@ -4,7 +4,7 @@
 	"type" : "collection-analysis",
 	"phase" : "collection-exploration",
 	"description" : "With this recipe it is possible to: 1) select collections, 2) inspect their metadata, 3) perform data analytics tasks on their metadata (e.g., detect incomplete data, observe value distributions along date fields), and 4) send them to the other browsing and search recipes.",
-	"recipeDescription" : "<p>This recipe is made to support “data critique”. With this recipe it is possible to:</p><br /> 1) Select collections <br />2) Inspect their metadata <br />3) Perform data analytics tasks on their metadata (e.g., detect incomplete data, observe value distributions along date fields) <br /> 4) Send them to the other browsing and search recipes</br></br><a target=\"_blank\" href=\"https://clariah.github.io/mediasuite-info/pages/tools.html#docs-tools-inspect-metadata\">More info</a>",
+	"recipeDescription" : "<p>This recipe is made to support “data critique”. With this recipe it is possible to:</p><br /> 1) Select collections <br />2) Inspect their metadata <br />3) Perform data analytics tasks on their metadata (e.g., detect incomplete data, observe value distributions along date fields) <br /> 4) Send them to the other browsing and search recipes</br></br><a target=\"_blank\" href=\"/documentation/tools/collection-inspector\">More info</a>",
 	"inRecipeList" : true,
 	"ingredients" : {
 		"useProjects" : true,

--- a/src/resources/recipes/comparative-search.json
+++ b/src/resources/recipes/comparative-search.json
@@ -4,7 +4,7 @@
 	"type" : "comparative-search",
 	"phase" : "search",
 	"description" : "Supports comparative (re)search based on multiple queries on the same or different collections.",
-	"recipeDescription" : "<p>Supports comparative (re)search based on multiple queries on the same or different collections of choice. </p></br></br><a target=\"_blank\" href=\"https://clariah.github.io/mediasuite-info/pages/tools.html#docs-tools-compare\">More info</a>",
+	"recipeDescription" : "<p>Supports comparative (re)search based on multiple queries on the same or different collections of choice. </p></br></br><a target=\"_blank\" href=\"/documentation/tools/comparison-search\">More info</a>",
 	"inRecipeList" : true,
 	"useCustomTemplate" : false,
 	"ingredients" : {

--- a/src/resources/recipes/query-comparison.json
+++ b/src/resources/recipes/query-comparison.json
@@ -1,0 +1,18 @@
+{
+  "id" : "query-comparison",
+  "name" : "Compare your saved queries",
+  "type" : "query-comparison",
+  "phase" : "search",
+  "description" : "Compare saved queries.",
+  "recipeDescription" : "<p>Compare saved queries based on multiple queries on the same or different collections of choice. </p></br></br><a target=\"_blank\" href=\"https://clariah.github.io/mediasuite-info/pages/tools.html#docs-tools-compare\">More info</a>",
+  "inRecipeList" : true,
+  "useCustomTemplate" : false,
+  "ingredients" : {
+    "collectionSelector" : true,
+    "output" : "lineChart",
+    "aggregationView" : "box",
+    "dateRangeSelector" : "date-picker",
+    "itemDetailsPath" : "tool/default-item-details",
+    "useProjects" : true
+  }
+}

--- a/src/resources/recipes/query-comparison.json
+++ b/src/resources/recipes/query-comparison.json
@@ -4,7 +4,7 @@
   "type" : "query-comparison",
   "phase" : "search",
   "description" : "Compare saved queries.",
-  "recipeDescription" : "<p>Compare saved queries based on multiple queries on the same or different collections of choice. </p></br></br><a target=\"_blank\" href=\"https://clariah.github.io/mediasuite-info/pages/tools.html#docs-tools-compare\">More info</a>",
+  "recipeDescription" : "<p>Compare saved queries based on multiple queries on the same or different collections of choice. </p></br></br><a target=\"_blank\" href=\"/documentation/tools/query-comparison\">More info</a>",
   "inRecipeList" : true,
   "useCustomTemplate" : false,
   "ingredients" : {

--- a/src/resources/recipes/single-search.json
+++ b/src/resources/recipes/single-search.json
@@ -4,7 +4,7 @@
 	"type" : "single-search",
 	"phase" : "search",
 	"description" : "Dedicated recipe for searching/exploring through a single collection and all available annotation layers for that collection (e.g., automatically-generated, user-generated, archival generated).",
-	"recipeDescription" : "<p>Dedicated recipe for searching/exploring through a single collection of choice by using facets and other filters.</p> </br></br><a target=\"_blank\" href=\"https://clariah.github.io/mediasuite-info/pages/tools.html#docs-tools-search\">More info</a>",
+	"recipeDescription" : "<p>Dedicated recipe for searching/exploring through a single collection of choice by using facets and other filters.</p> </br></br><a target=\"_blank\" href=\"/documentation/tools/single-search\">More info</a>",
 	"inRecipeList" : true,
 	"ingredients" : {
 		"collectionSelector" : true,

--- a/src/server.py
+++ b/src/server.py
@@ -574,6 +574,8 @@ def fielddescriptions(jsonFile):
 
 
 # Documentation snippet for help fields, loaded from CLARIAH/mediasuite-info repository
+# In case of high traffic; this function could be optimized by temporarily caching
+# the markdown results. See: http://flask.pocoo.org/docs/1.0/patterns/caching/
 @app.route('/help/<path:path>')
 def help(path):
 	if 'DOCUMENTATION_BASE_URL' in app.config:
@@ -584,6 +586,8 @@ def help(path):
 		return Response("Error: Please setup DOCUMENTATION_BASE_URL in your settings.py")
 
 # Documentation, loaded from CLARIAH/mediasuite-info repository
+# In case of high traffic; this function could be optimized by temporarily caching
+# the markdown results. See: http://flask.pocoo.org/docs/1.0/patterns/caching/
 @app.route('/documentation', defaults={'path': ''} )
 @app.route('/documentation/<path:path>')
 def documentation(path):

--- a/src/server.py
+++ b/src/server.py
@@ -568,6 +568,14 @@ def fielddescriptions(jsonFile):
 		return redirect("%s/%s" % (app.config['FIELD_DESCRIPTION_BASE_URL'], jsonFile), code=302)
 	return Response(getErrorMessage('Not configured for this instance'), mimetype='application/json')
 
+
+# Load help pages from external source
+@app.route('/help/<path:path>')
+def help(path):
+	if 'HELP_BASE_URL' in app.config:
+		return redirect("%s/%s" % (app.config['HELP_BASE_URL'], path), code=302)
+	return Response(getErrorMessage('Not configured for this instance'), mimetype='application/json')
+
 """------------------------------------------------------------------------------
 EXPLORATORY SEARCH / DIVE+ WRAPPER
 ------------------------------------------------------------------------------"""

--- a/src/server.py
+++ b/src/server.py
@@ -576,8 +576,8 @@ def fielddescriptions(jsonFile):
 # Documentation snippet for help fields, loaded from CLARIAH/mediasuite-info repository
 @app.route('/help/<path:path>')
 def help(path):
-	if 'HELP_BASE_URL' in app.config:
-		resp = requests.get("%s/docs/%s.md" % (app.config['HELP_BASE_URL'], path))
+	if 'DOCUMENTATION_BASE_URL' in app.config:
+		resp = requests.get("%s/docs/%s.md" % (app.config['DOCUMENTATION_BASE_URL'], path))
 		html = markdown.markdown(resp.text)
 		return Response(html)
 	
@@ -589,9 +589,9 @@ def help(path):
 def documentation(path):
 	toc=""
 	content=""
-	if 'HELP_BASE_URL' in app.config:
+	if 'DOCUMENTATION_BASE_URL' in app.config:
 		# retrieve toc
-		resp = requests.get("%s/%s" % (app.config['HELP_BASE_URL'], "content.json"))
+		resp = requests.get("%s/%s" % (app.config['DOCUMENTATION_BASE_URL'], "content.json"))
 		toc=resp.json()
 		
 		# default to first item
@@ -599,7 +599,7 @@ def documentation(path):
 			path = toc[0]['content']
 		
 		# retrieve document from documentation repository
-		resp = requests.get("%s/docs/%s.md" % (app.config['HELP_BASE_URL'], path))
+		resp = requests.get("%s/docs/%s.md" % (app.config['DOCUMENTATION_BASE_URL'], path))
 		content = markdown.markdown(resp.text)
 	
 	return render_template('documentation.html', 

--- a/src/server.py
+++ b/src/server.py
@@ -580,8 +580,8 @@ def help(path):
 		resp = requests.get("%s/docs/%s.md" % (app.config['DOCUMENTATION_BASE_URL'], path))
 		html = markdown.markdown(resp.text)
 		return Response(html)
-	
-	return Response(getErrorMessage('Not configured for this instance'), mimetype='application/json')
+	else:
+		return Response("Error: Please setup DOCUMENTATION_BASE_URL in your settings.py")
 
 # Documentation, loaded from CLARIAH/mediasuite-info repository
 @app.route('/documentation', defaults={'path': ''} )
@@ -601,6 +601,8 @@ def documentation(path):
 		# retrieve document from documentation repository
 		resp = requests.get("%s/docs/%s.md" % (app.config['DOCUMENTATION_BASE_URL'], path))
 		content = markdown.markdown(resp.text)
+	else:
+		content = "Error: Please setup DOCUMENTATION_BASE_URL in your settings.py"
 	
 	return render_template('documentation.html', 
 						path=path,

--- a/src/server.py
+++ b/src/server.py
@@ -573,10 +573,11 @@ def fielddescriptions(jsonFile):
 	return Response(getErrorMessage('Not configured for this instance'), mimetype='application/json')
 
 
-# Documentation snippet for help fields, loaded from CLARIAH/mediasuite-info repository
+# Documentation for a specific feature, shown in the container behind the question mark button.
+# Data is loaded from CLARIAH/mediasuite-info repository.
 # In case of high traffic; this function could be optimized by temporarily caching
 # the markdown results. See: http://flask.pocoo.org/docs/1.0/patterns/caching/
-@app.route('/help/<path:path>')
+@app.route('/feature-doc/<path:path>')
 def help(path):
 	if 'DOCUMENTATION_BASE_URL' in app.config:
 		resp = requests.get("%s/docs/%s.md" % (app.config['DOCUMENTATION_BASE_URL'], path))

--- a/src/server.py
+++ b/src/server.py
@@ -374,10 +374,14 @@ def searchAPI(operation, collectionId):
 		postData = request.get_json(force=True)
 	except Exception, e:
 		print e
-	resp = getErrorMessage('Invalid operation specified')
+	errorResp = getErrorMessage('Invalid operation specified')
 	if operation == 'layered_search':
 		resp = _workspace.layeredSearch(getClientId(), getToken(), collectionId, postData)
-	return Response(resp, mimetype='application/json')
+		if resp:
+			return Response(resp, mimetype='application/json')
+		else:
+			errorResp = getErrorMessage('Nothing found')
+	return Response(errorResp, mimetype='application/json')
 
 @app.route('/search-api/sparql', methods=['POST'])
 @requires_auth
@@ -557,6 +561,12 @@ def logout():
 		return redirect(url_for('home'))
 	return Response(getErrorMessage('logout not implemented'))
 
+
+@app.route('/fielddescriptions/<jsonFile>')
+def fielddescriptions(jsonFile):
+	if 'FIELD_DESCRIPTION_BASE_URL' in app.config:
+		return redirect("%s/%s" % (app.config['FIELD_DESCRIPTION_BASE_URL'], jsonFile), code=302)
+	return Response(getErrorMessage('Not configured for this instance'), mimetype='application/json')
 
 """------------------------------------------------------------------------------
 EXPLORATORY SEARCH / DIVE+ WRAPPER

--- a/src/settings-example.py
+++ b/src/settings-example.py
@@ -17,6 +17,12 @@ class Config(object):
 
 	ANNOTATION_API = 'http://localhost:5300/api'
 
+	USER_SPACE_API = 'http://localhost:5306/api/v0.1'
+
+	PLAYOUT_API = 'http://localhost:99999'
+
+	FIELD_DESCRIPTION_BASE_URL = 'http://localhost'
+
 	EXPORT_CONFIGS = {
 
 	}

--- a/src/settings-example.py
+++ b/src/settings-example.py
@@ -23,6 +23,8 @@ class Config(object):
 
 	FIELD_DESCRIPTION_BASE_URL = 'http://localhost'
 
+	DOCUMENTATION_BASE_URL = 'https://raw.githubusercontent.com/CLARIAH/mediasuite-info/master'
+
 	EXPORT_CONFIGS = {
 
 	}

--- a/src/static/js/common.js
+++ b/src/static/js/common.js
@@ -28,8 +28,3 @@ function breadcrumb() {
 
   $('.BreadCrumbs').removeClass('hidden').html(breadcrumb);
 }
-
-// Info/help popup window.
-$('.cl_button, .cl_close').on('click', function () {
-  $('.cl_container-help').toggleClass('cl_active');
-});

--- a/src/static/js/help.js
+++ b/src/static/js/help.js
@@ -1,0 +1,63 @@
+/**
+ * Enable question mark button and show help
+ */
+
+function initHelp(helpTitle, contentUrl){
+  
+  var initialized = false;
+  var container, button, title, close, content;
+
+  // initialize
+  function initDOM(){
+
+      if (initialized){
+          return true;
+      }
+
+      container = document.getElementById('help_container');
+      button = document.getElementById('help_button');
+      title = document.getElementById('help_title');
+      close = document.getElementById('help_close');
+      content = document.getElementById('help_content');
+
+      if (!container || !button || !title || !content || !close){
+          console.error('Could not find help DOM');
+          return false;
+      }
+
+      // show help
+      button.onclick = ()=>{
+          container.style.display = 'block';
+      }
+
+      // close help
+      close.onclick = ()=>{
+          container.style.display = 'none';
+      }
+      return true;
+  }
+  
+  // load data from the given url to the content container
+  function loadData(contentUrl){
+      content.innerHTML = "Loading...";
+      fetch(contentUrl).then(function(response){
+          if (response.status !== 200){
+              return 'Could not load the help data. Please make sure it is available at: <a href="'+contentUrl+'">' + contentUrl + '</a>';
+          }
+          return response.text();
+      }).then(function(html){
+          content.innerHTML = html;
+      }).catch(function(error){
+          console.warn(error);
+      });
+  }
+
+  // init help with given titel and content Url
+  if (!initDOM()){
+      // an error occured during init
+      return;
+  }
+          
+  title.innerHTML = helpTitle;
+  loadData(contentUrl);
+}

--- a/src/static/package.json
+++ b/src/static/package.json
@@ -32,7 +32,7 @@
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "jquery": "^3.2.1",
-    "labo-components": "2.0.0",
+    "labo-components": "2.0.1",
     "nouislider": "^10.1.0",
     "openseadragon": "^2.3.0"
   },

--- a/src/static/package.json
+++ b/src/static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clariah-media-suite",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "CMS for the Mind of the Universe project",
   "main": "webpack.config.js",
   "repository": {
@@ -32,7 +32,7 @@
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "jquery": "^3.2.1",
-    "labo-components": "2.0.2",
+    "labo-components": "2.0.3",
     "nouislider": "^10.1.0",
     "openseadragon": "^2.3.0"
   },

--- a/src/static/package.json
+++ b/src/static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clariah-media-suite",
-  "version": "1.9.0",
+  "version": "2.0.0",
   "description": "CMS for the Mind of the Universe project",
   "main": "webpack.config.js",
   "repository": {
@@ -32,7 +32,7 @@
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "jquery": "^3.2.1",
-    "labo-components": "1.9.2",
+    "labo-components": "2.0.0",
     "nouislider": "^10.1.0",
     "openseadragon": "^2.3.0"
   },

--- a/src/static/package.json
+++ b/src/static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clariah-media-suite",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "CMS for the Mind of the Universe project",
   "main": "webpack.config.js",
   "repository": {
@@ -32,7 +32,7 @@
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "jquery": "^3.2.1",
-    "labo-components": "2.0.1",
+    "labo-components": "2.0.2",
     "nouislider": "^10.1.0",
     "openseadragon": "^2.3.0"
   },

--- a/src/static/package.json
+++ b/src/static/package.json
@@ -32,7 +32,7 @@
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "jquery": "^3.2.1",
-    "labo-components": "1.9.1",
+    "labo-components": "1.9.2",
     "nouislider": "^10.1.0",
     "openseadragon": "^2.3.0"
   },

--- a/src/static/sass/_components.scss
+++ b/src/static/sass/_components.scss
@@ -12,3 +12,4 @@
 @import "style/layout";
 @import "tools/tools";
 @import "homepage/homepage";
+@import "documentation/documentation";

--- a/src/static/sass/breadcrumbs/_breadcrumbs.scss
+++ b/src/static/sass/breadcrumbs/_breadcrumbs.scss
@@ -1,5 +1,4 @@
 .BreadCrumbs{
-  background-color: $clWhite;
   box-sizing: border-box;
   display: inline-block;
   font-family: $fontBody;

--- a/src/static/sass/documentation/_documentation.scss
+++ b/src/static/sass/documentation/_documentation.scss
@@ -2,7 +2,7 @@
     .container{
         width: 1024px;
         max-width: 100%;
-        min-height: calc(100vh - 310px);
+        min-height: calc(100vh - 332px);
 
         ul{
             margin:0;
@@ -12,24 +12,34 @@
                 position: fixed;
                 top: 140px;
                 width: 200px;
+
+                @media screen and (max-width: $break-medium) {
+                    width: 100%;
+                    position: relative;
+                    top: 0;
+                }
+
                 &>li{
                     font-weight: bold;
                 }
             }
             li{
                 font-weight: normal;
-                margin-left: 0;  
+                margin: 2px 0;
                 padding-left: 10px;              
                 a{
                     display: block;
                     padding: 3px 0 3px 15px;
                     border-left: 0;
                     color: black;
-                    &:hover{
-                        text-decoration: none;
+                    text-decoration: none;
+                    &:hover{                        
+                        padding-left: 10px;
+                        font-weight: bold;
+                        border-left: 5px solid $clSecondary;
                     }
                 }
-                &.active, &:hover{
+                &.active{
                     &>a{
                         padding-left: 10px;
                         font-weight: bold;
@@ -42,6 +52,9 @@
 
         .documentation-content{
             margin-left: 225px;
+            @media screen and (max-width: $break-medium) {
+                margin-left: 0;
+            }
         }
     }
 }

--- a/src/static/sass/documentation/_documentation.scss
+++ b/src/static/sass/documentation/_documentation.scss
@@ -4,49 +4,51 @@
         max-width: 100%;
         min-height: calc(100vh - 332px);
 
-        ul{
-            margin:0;
-            padding: 0;
-            list-style: none;
-            &.toc{
-                position: fixed;
-                top: 140px;
-                width: 200px;
+        .toc{
+            ul{
+                margin:0;
+                padding: 0;
+                list-style: none;
+                &.root{
+                    position: fixed;
+                    top: 140px;
+                    width: 200px;
 
-                @media screen and (max-width: $break-medium) {
-                    width: 100%;
-                    position: relative;
-                    top: 0;
-                }
+                    @media screen and (max-width: $break-medium) {
+                        width: 100%;
+                        position: relative;
+                        top: 0;
+                    }
 
-                &>li{
-                    font-weight: bold;
-                }
-            }
-            li{
-                font-weight: normal;
-                margin: 2px 0;
-                padding-left: 10px;              
-                a{
-                    display: block;
-                    padding: 3px 0 3px 15px;
-                    border-left: 0;
-                    color: black;
-                    text-decoration: none;
-                    &:hover{                        
-                        padding-left: 10px;
+                    &>li{
                         font-weight: bold;
-                        border-left: 5px solid $clSecondary;
                     }
                 }
-                &.active{
-                    &>a{
-                        padding-left: 10px;
-                        font-weight: bold;
-                        border-left: 5px solid $clSecondary;
+                li{
+                    font-weight: normal;
+                    margin: 2px 0;
+                    padding-left: 10px;              
+                    a{
+                        display: block;
+                        padding: 3px 0 3px 15px;
+                        border-left: 0;
+                        color: black;
+                        text-decoration: none;
+                        &:hover{                        
+                            padding-left: 10px;
+                            font-weight: bold;
+                            border-left: 5px solid $clSecondary;
+                        }
                     }
-                }
+                    &.active{
+                        &>a{
+                            padding-left: 10px;
+                            font-weight: bold;
+                            border-left: 5px solid $clSecondary;
+                        }
+                    }
 
+                }
             }
         }
 

--- a/src/static/sass/documentation/_documentation.scss
+++ b/src/static/sass/documentation/_documentation.scss
@@ -1,0 +1,47 @@
+.documentation{
+    .container{
+        width: 1024px;
+        max-width: 100%;
+        min-height: calc(100vh - 310px);
+
+        ul{
+            margin:0;
+            padding: 0;
+            list-style: none;
+            &.toc{
+                position: fixed;
+                top: 140px;
+                width: 200px;
+                &>li{
+                    font-weight: bold;
+                }
+            }
+            li{
+                font-weight: normal;
+                margin-left: 0;  
+                padding-left: 10px;              
+                a{
+                    display: block;
+                    padding: 3px 0 3px 15px;
+                    border-left: 0;
+                    color: black;
+                    &:hover{
+                        text-decoration: none;
+                    }
+                }
+                &.active, &:hover{
+                    &>a{
+                        padding-left: 10px;
+                        font-weight: bold;
+                        border-left: 5px solid $clSecondary;
+                    }
+                }
+
+            }
+        }
+
+        .documentation-content{
+            margin-left: 225px;
+        }
+    }
+}

--- a/src/static/sass/help/help.scss
+++ b/src/static/sass/help/help.scss
@@ -1,5 +1,22 @@
 .cl_help {
   color: $clDark;
+
+
+  // limit heading size for readability
+  h1{
+    font-size: 1.5em;
+  }
+  h2{
+    font-size: 1.3em;
+  }
+  h3{
+    font-size: 1.2em;
+  }
+
+  // prevent large gap on top of help container
+  h1:first-child, h2:first-child,h3:first-child{
+    margin-top: 0px;
+  }
 }
 
 @media all and (max-width: 960px) {

--- a/src/templates/data-sources.html
+++ b/src/templates/data-sources.html
@@ -42,6 +42,6 @@
 <script src="/static/js/common.js"></script>
 
 <script src="/static/js/help.js"></script>
-<script>initHelp("Data", "/help/pages/data.html");</script>
+<script>initHelp("Data", "/help/data");</script>
 
 </html>

--- a/src/templates/data-sources.html
+++ b/src/templates/data-sources.html
@@ -42,6 +42,6 @@
 <script src="/static/js/common.js"></script>
 
 <script src="/static/js/help.js"></script>
-<script>initHelp("Data", "/help/data");</script>
+<script>initHelp("Data", "/feature-doc/data");</script>
 
 </html>

--- a/src/templates/data-sources.html
+++ b/src/templates/data-sources.html
@@ -41,4 +41,7 @@
 <script src="/static/node_modules/jquery/dist/jquery.min.js"></script>
 <script src="/static/js/common.js"></script>
 
+<script src="/static/js/help.js"></script>
+<script>initHelp("Data", "/help/pages/data.html");</script>
+
 </html>

--- a/src/templates/documentation.html
+++ b/src/templates/documentation.html
@@ -16,37 +16,39 @@
 
     <div class="container">
         {# TOC #}
-        <ul class="toc">
-        {% for item in toc %}   
-            {# level 1 #}     
-            <li {% if item.content == path %}class="active"{% endif %}>
-                <a href="/documentation/{{item.content}}">{{ item.title }}</a>
-                {# level 2 #}
-                {% if item.children and path.startswith(item.content) %}
-                    <ul>
-                        {% for subItem in item.children %}
-                            <li {% if subItem.content == path %}class="active"{% endif %}>
-                                <a href="/documentation/{{subItem.content}}">{{ subItem.title }}</a>
+        <div class="toc">
+        <ul class="root">
+            {% for item in toc %}   
+                {# level 1 #}     
+                <li {% if item.content == path %}class="active"{% endif %}>
+                    <a href="/documentation/{{item.content}}">{{ item.title }}</a>
+                    {# level 2 #}
+                    {% if item.children and path.startswith(item.content) %}
+                        <ul>
+                            {% for subItem in item.children %}
+                                <li {% if subItem.content == path %}class="active"{% endif %}>
+                                    <a href="/documentation/{{subItem.content}}">{{ subItem.title }}</a>
 
-                                {# level 3 #}
-                                {% if subItem.children %}
-                                    <ul>
-                                        {% for subSubItem in subItem.children %}
-                                            <li {% if subSubItem.content == path %}class="active"{% endif %}>
-                                                <a href="/documentation/{{subSubItem.content}}">{{ subSubItem.title }}</a>
-                                            </li>
-                                        {% endfor %}
-                                    </ul>
-                                {% endif %}
+                                    {# level 3 #}
+                                    {% if subItem.children %}
+                                        <ul>
+                                            {% for subSubItem in subItem.children %}
+                                                <li {% if subSubItem.content == path %}class="active"{% endif %}>
+                                                    <a href="/documentation/{{subSubItem.content}}">{{ subSubItem.title }}</a>
+                                                </li>
+                                            {% endfor %}
+                                        </ul>
+                                    {% endif %}
 
-                            </li>
-                        {% endfor %}
-                    </ul>
-                {% endif %}
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    {% endif %}
 
-            </li>
-        {% endfor %}
-        </ul>
+                </li>
+            {% endfor %}
+            </ul>
+        </div>
 
         {# Content #}
         <div class="documentation-content">

--- a/src/templates/documentation.html
+++ b/src/templates/documentation.html
@@ -1,0 +1,66 @@
+<!doctype HTML>
+<html>
+
+<head>
+    <title>CLARIAH Media Suite - Documentation</title>
+
+    {% include 'head.html' %}
+
+</head>
+
+<body class="documentation">
+
+    {% with page='documentation' %}
+    {% include 'nav.html' %}
+    {% endwith %}
+
+    <div class="container">
+        {# TOC #}
+        <ul class="toc">
+        {% for item in toc %}   
+            {# level 1 #}     
+            <li {% if item.content == path %}class="active"{% endif %}>
+                <a href="/documentation/{{item.content}}">{{ item.title }}</a>
+                {# level 2 #}
+                {% if item.children and path.startswith(item.content) %}
+                    <ul>
+                        {% for subItem in item.children %}
+                            <li {% if subItem.content == path %}class="active"{% endif %}>
+                                <a href="/documentation/{{subItem.content}}">{{ subItem.title }}</a>
+
+                                {# level 3 #}
+                                {% if subItem.children %}
+                                    <ul>
+                                        {% for subSubItem in subItem.children %}
+                                            <li {% if subSubItem.content == path %}class="active"{% endif %}>
+                                                <a href="/documentation/{{subSubItem.content}}">{{ subSubItem.title }}</a>
+                                            </li>
+                                        {% endfor %}
+                                    </ul>
+                                {% endif %}
+
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+
+            </li>
+        {% endfor %}
+        </ul>
+
+        {# Content #}
+        <div class="documentation-content">
+            {{ content | safe}}
+        </div>
+    </div>
+
+    {% include 'footer.html' %}
+
+    {% include 'site-tracking.html' ignore missing %}
+
+</body>
+
+<script src="/static/node_modules/jquery/dist/jquery.min.js"></script>
+<script src="/static/js/common.js"></script>
+
+</html>

--- a/src/templates/exploratory-search.html
+++ b/src/templates/exploratory-search.html
@@ -22,7 +22,7 @@
 </body>
 
 <script src="/static/js/help.js"></script>
-<script>initHelp("Explore", "/help/tools/exploratory-search");</script>
+<script>initHelp("Explore", "/feature-doc/tools/exploratory-search");</script>
 
 {% include 'site-tracking.html' ignore missing %}
 

--- a/src/templates/exploratory-search.html
+++ b/src/templates/exploratory-search.html
@@ -15,10 +15,15 @@
 	{% include 'nav.html' %}
 	{% endwith %}
 
-	<iframe id="bg__tools-explore" src="http://diveplus.frontwise.com{{params.path}}"/>
+    
+    <iframe id="bg__tools-explore" src="http://diveplus.frontwise.com{{params.path}}"></iframe>
 
-	{% include 'site-tracking.html' ignore missing %}
 
 </body>
+
+<script src="/static/js/help.js"></script>
+<script>initHelp("Explore", "/help/pages/tools/exploratory-search.html");</script>
+
+{% include 'site-tracking.html' ignore missing %}
 
 </html>

--- a/src/templates/exploratory-search.html
+++ b/src/templates/exploratory-search.html
@@ -22,7 +22,7 @@
 </body>
 
 <script src="/static/js/help.js"></script>
-<script>initHelp("Explore", "/help/pages/tools/exploratory-search.html");</script>
+<script>initHelp("Explore", "/help/tools/exploratory-search");</script>
 
 {% include 'site-tracking.html' ignore missing %}
 

--- a/src/templates/footer.html
+++ b/src/templates/footer.html
@@ -4,7 +4,7 @@
             <li>
                 <div class="logo"></div>
                 <h5>
-                    Version:  <a href="https://clariah.github.io/mediasuite-info/pages/release-notes.html#release-notes-v2-1">2.1</a>
+                    Version:  <a href="/documentation/release-notes#release-notes-v2-1">2.1</a>
                 </h5>
             </li>
         </ul>
@@ -21,7 +21,7 @@
                 <a href="/about">About</a>
             </li>
             <li>
-                <a href="https://clariah.github.io/mediasuite-info/">Documentation</a>
+                <a href="/documentation">Documentation</a>
             </li>
             <li>
                 <a href="/contact">Contact</a>

--- a/src/templates/help.html
+++ b/src/templates/help.html
@@ -2,25 +2,9 @@
     <div class="cl_button" id="help_button"></div>
     <div class="cl_container-help" id="help_container">
         <div class="cl_header">
-            <span id="help_title">
-                {% if page=='data-sources' %}
-                    {{data_static['help_header']}}
-                {% elif page=='tools' %}
-                    {{recipes['pages']['tools-page'].help_header}}
-                {% elif page=='tool' %}
-                    {{recipe.name | safe}}
-            {% endif %}
-            </span>
+            <span id="help_title"></span>
             <div class="cl_close" id="help_close"></div>
         </div>
-        <div class="cl_scroll" id="help_content">
-            {% if page=='data-sources' %}
-                {{data_static['documentation_question-mark_data_page'] | safe}}
-            {% elif page=='tools' %}
-                {{recipes['pages']['tools-page']['documentation_question-mark_tools_page']|safe}}
-            {% elif page=='tool' %}
-                {{recipe.recipeDescription | safe}}
-            {% endif %}
-        </div>
+        <div class="cl_scroll" id="help_content"></div>
     </div>
 </div>

--- a/src/templates/nav.html
+++ b/src/templates/nav.html
@@ -48,7 +48,7 @@
 			{% endif %}
 
 			<li>
-				<a href="https://clariah.github.io/mediasuite-info/pages/notebooks.html">Jupyter Notebooks</a>
+				<a href="/documentation/workspace/jupyter-notebooks">Jupyter Notebooks</a>
 			</li>
 			
 		</ul>

--- a/src/templates/nav.html
+++ b/src/templates/nav.html
@@ -61,7 +61,7 @@
 				<a href="/about">About</a>
 			</li>
 			<li class="{{ 'active' if page == 'documentation' }}">
-				<a href="https://clariah.github.io/mediasuite-info/">Documentation</a>
+				<a href="/documentation">Documentation</a>
 			</li>
 			<li class="{{ 'active' if page == 'contact' }}">
 				<a href="/contact">Contact</a>

--- a/src/templates/recipes.html
+++ b/src/templates/recipes.html
@@ -124,7 +124,7 @@
 <script src="/static/js/common.js"></script>
 
 <script src="/static/js/help.js"></script>
-<script>initHelp("Data", "/feature-doc/tools");</script>
+<script>initHelp("Tools", "/feature-doc/tools");</script>
 
 
 </html>

--- a/src/templates/recipes.html
+++ b/src/templates/recipes.html
@@ -122,9 +122,8 @@
 
 <script src="/static/node_modules/jquery/dist/jquery.min.js"></script>
 <script src="/static/js/common.js"></script>
+
 <script src="/static/js/help.js"></script>
-<script>
-initHelp("Tools", "https://raw.githubusercontent.com/CLARIAH/mediasuite-info/master/pages/tools.html");
-</script>
+<script>initHelp("Explore", "/help/pages/tools.html");</script>
 
 </html>

--- a/src/templates/recipes.html
+++ b/src/templates/recipes.html
@@ -97,8 +97,10 @@
             -->
 
             <div class="tool cl_col cl_col-span-6 cl_no_padd_left cl_margin-botton">
-               <div class="image-wrap">
-                   <img src="../static/images/tools/comparative-queries-screenshot-min.png" alt="Comparative search">
+               <div class="image-wrap hover">
+                    <a href="{{recipes['pages']['tools-page']['tools_query-comparison'].links.link_details.link_url}}">
+                      <img src="../static/images/tools/comparative-queries-screenshot-min.png" alt="Comparative search">
+                    </a>
                </div>
                <h3>{{recipes['pages']['tools-page']['tools_query-comparison'].header}}</h3>
                <div class="actions">
@@ -120,5 +122,9 @@
 
 <script src="/static/node_modules/jquery/dist/jquery.min.js"></script>
 <script src="/static/js/common.js"></script>
+<script src="/static/js/help.js"></script>
+<script>
+initHelp("Tools", "https://raw.githubusercontent.com/CLARIAH/mediasuite-info/master/pages/tools.html");
+</script>
 
 </html>

--- a/src/templates/recipes.html
+++ b/src/templates/recipes.html
@@ -124,7 +124,7 @@
 <script src="/static/js/common.js"></script>
 
 <script src="/static/js/help.js"></script>
-<script>initHelp("Data", "/help/tools");</script>
+<script>initHelp("Data", "/feature-doc/tools");</script>
 
 
 </html>

--- a/src/templates/recipes.html
+++ b/src/templates/recipes.html
@@ -74,6 +74,7 @@
                 </div>
             </div>
 
+            <!--
             <div class="tool cl_col cl_col-span-3">
                 <div class="image-wrap">
                     <img src="../static/images/tools/comparative-queries-screenshot-min.png" alt="Comparative search">
@@ -86,6 +87,20 @@
                        class="btn">{{recipes['pages']['tools-page']['tools_comparative-search'].links.link_open.link_value}}</a>
                 </div>
             </div>
+            -->
+
+            <div class="tool cl_col cl_col-span-6 cl_no_padd_left cl_margin-botton">
+               <div class="image-wrap">
+                   <img src="../static/images/tools/comparative-queries-screenshot-min.png" alt="Comparative search">
+               </div>
+               <h3>{{recipes['pages']['tools-page']['tools_query-comparison'].header}}</h3>
+               <div class="actions">
+                   <a href="{{recipes['pages']['tools-page']['tools_query-comparison'].links.link_details.link_url}}"
+                      class="btn blank">{{recipes['pages']['tools-page']['tools_query-comparison'].links.link_details.link_value}}</a>
+                   <a href="{{recipes['pages']['tools-page']['tools_query-comparison'].links.link_open.link_url}}"
+                      class="btn">{{recipes['pages']['tools-page']['tools_query-comparison'].links.link_open.link_value}}</a>
+               </div>
+           </div>
 
         </div>
     </div>

--- a/src/templates/recipes.html
+++ b/src/templates/recipes.html
@@ -124,6 +124,7 @@
 <script src="/static/js/common.js"></script>
 
 <script src="/static/js/help.js"></script>
-<script>initHelp("Explore", "/help/pages/tools.html");</script>
+<script>initHelp("Data", "/help/tools");</script>
+
 
 </html>


### PR DESCRIPTION
Both the documentation page as the feature specific help pages are now loaded from /documentation . It uses markdown and a content.json from an external documentation repository. Results are cached for 5 minutes.

- Add: `DOCUMENTATION_BASE_URL = 'https://raw.githubusercontent.com/Frontwise/mediasuite-info/master'`   to your settings.py. The url will change (this week) to the CLARIAH/mediasuite-info  repository of which our repo is a fork. Liliana is adding the content.

- Install a markdown processor for python: `pip install markdown`. This is needed to process the markdown documentation pages to html.

- All urls to clariah.github.io/mediasuite-info/pages% have been rewritten to /documentation/%