### PR TITLE
Fix tool url for Comparative search

### DIFF
--- a/src/templates/recipes.html
+++ b/src/templates/recipes.html
@@ -81,7 +81,7 @@
 
             <div class="tool cl_col cl_col-span-6 cl_no_padd_left cl_margin-botton">
                <div class="image-wrap hover">
-                    <a href="{{recipes['pages']['tools-page']['tools_comparative-search'].links.link_open.link_url}}">
+                    <a href="{{recipes['pages']['tools-page']['tools_query-comparison'].links.link_open.link_url}}">
                       <img src="../static/images/tools/compare.png" alt="Comparative search">
                     </a>
                </div>


### PR DESCRIPTION
Currently wrong url, opens old tool.